### PR TITLE
Major changes to Kwargs mapping and Dict/Map types

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.19
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.19
+        go-version: 1.20
       id: go
 
     - name: Code checkout

--- a/go2star_test.go
+++ b/go2star_test.go
@@ -45,7 +45,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: true,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(true, &starval); err != nil {
+				if err := Go(true).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Truth() != true {
@@ -58,7 +58,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxInt32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Int
-				if err := goToStarlark(math.MaxInt32, &starval); err != nil {
+				if err := Go(math.MaxInt32).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.Int64()
@@ -75,7 +75,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxInt32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(math.MaxInt32, &starval); err != nil {
+				if err := Go(math.MaxInt32).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.(starlark.Int)
@@ -92,7 +92,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxInt32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval *starlark.Int
-				if err := goToStarlark(math.MaxInt32, &starval); err != nil {
+				if err := Go(math.MaxInt32).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.Int64()
@@ -109,7 +109,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: uint64(math.MaxUint64),
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Int
-				if err := goToStarlark(uint64(math.MaxUint64), &starval); err != nil {
+				if err := Go(uint64(math.MaxUint64)).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.Uint64()
@@ -126,7 +126,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: uint64(math.MaxUint64),
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval *starlark.Int
-				if err := goToStarlark(uint64(math.MaxUint64), &starval); err != nil {
+				if err := Go(uint64(math.MaxUint64)).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.Uint64()
@@ -143,7 +143,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: uint64(math.MaxUint64),
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(uint64(math.MaxUint64), &starval); err != nil {
+				if err := Go(uint64(math.MaxUint64)).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				val, ok := starval.(starlark.Int)
@@ -160,7 +160,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxFloat32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Float
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval != math.MaxFloat32 {
@@ -173,7 +173,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxFloat32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval *starlark.Float
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if *starval != math.MaxFloat32 {
@@ -186,7 +186,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: math.MaxFloat32,
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.(starlark.Float) != math.MaxFloat32 {
@@ -199,7 +199,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: "Hello World!",
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.String
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if string(starval) != `Hello World!` {
@@ -212,7 +212,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: "Hello World!",
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval *starlark.String
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if string(*starval) != `Hello World!` {
@@ -225,7 +225,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: "Hello World!",
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.String() != `"Hello World!"` {
@@ -238,7 +238,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: []string{"Hello", "World!"},
 			eval: func(t *testing.T, goVal interface{}) {
 				starval := make(starlark.Tuple, 2)
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 2 {
@@ -254,7 +254,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: []int{1, 2, math.MaxInt8},
 			eval: func(t *testing.T, goVal interface{}) {
 				starval := make(starlark.Tuple, 3)
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 3 {
@@ -272,7 +272,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: []interface{}{1, 2, 3, "Go!"},
 			eval: func(t *testing.T, goVal interface{}) {
 				starval := make(starlark.Tuple, 4)
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 4 {
@@ -289,7 +289,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: []int{1, 2, math.MaxInt8},
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Value
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				tuple := starval.(starlark.Tuple)
@@ -308,7 +308,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: []int{1, 2, math.MaxInt8},
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval *starlark.Tuple
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if len(*starval) != 3 {
@@ -326,7 +326,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: map[string]string{"msg": "hello", "target": "world"},
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Dict
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 2 {
@@ -348,7 +348,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: map[string]int{"one": 12, "two": math.MaxInt8, "three": math.MaxInt64},
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Dict
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 3 {
@@ -369,7 +369,7 @@ func TestGoToStarlark(t *testing.T) {
 			goVal: map[any]any{"one": "12", "two": math.MaxInt8, 3: math.MaxInt64},
 			eval: func(t *testing.T, goVal interface{}) {
 				var starval starlark.Dict
-				if err := goToStarlark(goVal, &starval); err != nil {
+				if err := Go(goVal).Starlark(&starval); err != nil {
 					t.Fatal(err)
 				}
 				if starval.Len() != 3 {

--- a/kwargs2go.go
+++ b/kwargs2go.go
@@ -31,7 +31,7 @@ type KwargsValue struct {
 //
 // Kwargs(kwargs).Go(&Param)
 //
-// Supported annotation: `name:"arg_name" optional:"true|false" (default false)`
+// Supported annotation: `name:"arg_name" required:"true|false" (default false)`
 func Kwargs(kwargs []starlark.Tuple) *KwargsValue {
 	return &KwargsValue{kwargs: kwargs}
 }
@@ -73,15 +73,16 @@ func kwargsToGo(kwargs []starlark.Tuple, goval reflect.Value) error {
 			return err
 		}
 
-		// is arg marked optional? By default args are optional=false
-		// arg is optional if it is explicitly marked with "true" or "yes"
-		argOptional, _ := field.Tag.Lookup("optional")
-		switch argOptional {
+		// is arg marked required? By default args are required=false
+		// an arg is required if it is explicitly marked with "true" or "yes"
+		// otherwise, it's ignored
+		argRequired, _ := field.Tag.Lookup("required")
+		switch argRequired {
 		case "true", "yes":
-		default:
 			if kwarg == starlark.None {
 				return fmt.Errorf("argument '%s' is required", argName)
 			}
+		default:
 		}
 
 		// set field value if not None


### PR DESCRIPTION
This PR updates introduces the following changes
*  When mapping Kwargs using structs, elements are considered optional by default
* Changes for better support of Go map conversions to dict or strict-dict types
* Changes for better support of Dict to Go map conversion when using empty interface as values.